### PR TITLE
Revert "Daily T5 Minimum and FT Count Progress"

### DIFF
--- a/COSORE Winter Rs Analysis.Rmd
+++ b/COSORE Winter Rs Analysis.Rmd
@@ -12,8 +12,6 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # Overall Science Question
 Question:
-How much does Rs during winter contribute to annual flux?
-Does the number of freeze-thaw events have an effect on the winter contribution?
 
 ## Sub Hypotheses:
 H1:
@@ -24,16 +22,9 @@ H3:
 # Loading Packages
 
 ```{r Load-Packages }
-library(dplyr)
-library(ggplot2)
-library(tidyr)
-library(lubridate)
-library(devtools)
-library(remotes)
-library(cosore)
 
-source("FTFindUsefulData.R")
 ```
+ 
  
 # Functions
  
@@ -48,26 +39,8 @@ source("FTFindUsefulData.R")
 
 # Load Data
 
-winterdata_names holds the names of the 8 datasets that have a full year of data and have a winter period that matches our definition. 
-
-winterdata holds the data tables of all the datasets in winter_datanames
-
-winterdata_full holds all the data of all the datasets in winterdata_names
-
 ```{r Load-data}
 #This is where we would load the data we are going to analyze
-
-winterdata_names
-
-winterdata <- list()
-for (i in 1:length(winterdata_names)) {
-  winterdata[[i]]<- csr_dataset(winterdata_names[i])$data
-}
-
-winterdata_full <- list()
-for (i in 1:length(winterdata_names)) {
-  winterdata_full[[i]]<- csr_dataset(winterdata_names[i])
-}
 
 ```
 
@@ -76,61 +49,6 @@ for (i in 1:length(winterdata_names)) {
 ```{r Clean-Data }
 
 ```
-
-
-# Calculate Number of Freeze Thaw Crossings: 
-
-```{r Freeze-Thaw-Crossings-Per-Year}
-
-results <- list()
-
-for(i in 1:length(winterdata_names)){
-  
-  message("I'm on ", winterdata_names[i]," now")
-  
-  ds<-winterdata_full[[i]]$data
-  ds %>%
-    ungroup() %>%
-    select(CSR_TIMESTAMP_BEGIN,CSR_T5) %>%
-    mutate(day=yday(CSR_TIMESTAMP_BEGIN),
-           year=year(CSR_TIMESTAMP_BEGIN)) -> ds1
-  ds1 %>%
-      filter(!is.na(CSR_T5)) %>%
-      group_by(year,day) %>%
-      summarise(CSR_TIMESTAMP=mean(CSR_TIMESTAMP_BEGIN),                    
-                T5_min=min(CSR_T5)) %>% 
-      ungroup() -> ds2
-  
-  
-  ds2 %>%
-    mutate(s=sign(T5_min)) %>%
-    group_by(year) %>%
-    summarise(ft_number = sum(s[-1] != s[-length(s)]) / 2)->
-    results[[winterdata_names[i]]]
-
-}
-
-ft_results<-bind_rows(results, .id = "dataset")
-
-
-```
-
-# Calculate Annual Rs by Year
-Current def of year is Jan 1 to Dec 31. 
-
-```{r rs-by-year}
-
-```
-
-# Calculate Winter Rs 
-Within calendar year Jan 1 - March 20, Dec 21 - Dec 31  
-
-```{}
-```
-
-
-# Calculate 
-
 
 # Hypothesis 1
 

--- a/FTFindUsefulData.R
+++ b/FTFindUsefulData.R
@@ -217,7 +217,7 @@ not5ay_names
 
 #Are any datasets missing both air temperature and t5 soil temperature?
 
-bothtempay_names<-c()
+bothtemp_names<-c()
 #will contain names of datasets with air and soil 5 cm temperature
 tempay_names<-c()
 #will contain names of datasets that have either air or soil 5 cm temperature
@@ -255,7 +255,7 @@ notempay_names
 # 22 datasets have at least air or t5 temperature data
 tempay_names
 # 0 datasets have both air and t5 soil temperature data
-bothtempay_names
+bothtemp_names
 
 
 
@@ -313,6 +313,7 @@ for(i in 1:runs){
 # 8 datasets in allyeardata_names have data that match our definition of winter
 winterdata_names
 print(winterdata_names)
+
 
 
 


### PR DESCRIPTION
@stephpenn1 I was meaning to merge the changes in "Freeze Thaw Count & Daily T5 Min Code Update" and open a pull request for you to review the changes in "Summarizing FTCs by Year" but I accidentally merged both. Kalyn told me to try reverting so I could still have you review the changes in "Summarizing FTCs by Year." Would you mind taking a look at these changes for me?

Here is a snapshot of the output of the new code in "Summarizing FTCs by Year." This code counts the number of FTCs in each year of data in each dataset then stores it in a tibble.

```
> ft_results
# A tibble: 34 x 3
   dataset              year ft_number
   <chr>               <dbl>     <dbl>
 1 d20190617_SCOTT_WKG  2017       1  
 2 d20190617_SCOTT_WKG  2018       0  
 3 d20190617_SCOTT_WKG  2019       0  
 4 d20200108_HE         2008       0.5
 5 d20200108_HE         2009       2  
 6 d20200108_HE         2010       2  
 7 d20200108_HE         2011       5  
 8 d20200108_HE         2012       6  
 9 d20200108_HE         2013       2.5
10 d20200212_KAYE_LNE   2015       0  
# ... with 24 more rows
```